### PR TITLE
[android] Fix bug 52541

### DIFF
--- a/toolkit/libtoolkit/src/main/java/lib/toolkit/base/managers/utils/StringUtils.kt
+++ b/toolkit/libtoolkit/src/main/java/lib/toolkit/base/managers/utils/StringUtils.kt
@@ -30,6 +30,7 @@ object StringUtils {
     val COMMON_MIME_TYPE = "*/*"
     val URI_ALLOWED_CHARS = "@#&=*+-_.,:!?()/~'%"
     @JvmField val DIALOG_FORBIDDEN_SYMBOLS = "*+:\"<>?|\\/"
+    val DIALOG_FORBIDDEN_NAMES = arrayOf(".", "..")
     val PATTERN_FORBIDDEN_SYMBOLS = ".*([$DIALOG_FORBIDDEN_SYMBOLS]*).*"
     val PATTERN_ALPHA_NUMERIC = "^[a-zA-Z0-9-]*$"
     val PATTERN_R7_CLOUDS = ".*(\\.r7-).*"
@@ -210,6 +211,10 @@ object StringUtils {
         } else {
             null
         }
+    }
+
+    fun getAllowedName(source: String): Boolean {
+        return source.trim() in DIALOG_FORBIDDEN_NAMES
     }
 
     @JvmStatic

--- a/toolkit/libtoolkit/src/main/java/lib/toolkit/base/ui/dialogs/common/holders/EditLineHolder.kt
+++ b/toolkit/libtoolkit/src/main/java/lib/toolkit/base/ui/dialogs/common/holders/EditLineHolder.kt
@@ -165,6 +165,11 @@ class EditLineHolder(private val dialog: CommonDialog) : BaseHolder(dialog) {
                 mEditInputLayout.error = mErrorValue + StringUtils.DIALOG_FORBIDDEN_SYMBOLS
                 mAcceptView.isEnabled = mResultString.length > 1
                 ""
+            } else if (StringUtils.getAllowedName(mResultString)) {
+                mErrorValue = dialog.getString(R.string.dialogs_edit_forbidden_name)
+                mEditInputLayout.error = mErrorValue
+                mAcceptView.isEnabled = false
+                null
             } else {
                 mErrorValue = null
                 mEditInputLayout.isErrorEnabled = false

--- a/toolkit/libtoolkit/src/main/res/values/translatable.xml
+++ b/toolkit/libtoolkit/src/main/res/values/translatable.xml
@@ -1,6 +1,7 @@
 <resources>
 
     <string name="dialogs_edit_forbidden_symbols">Do not use these symbols\u0020</string>
+    <string name="dialogs_edit_forbidden_name">Invalid name</string>
 
     <!-- File/Folder info -->
     <string name="sizes_bytes">Bytes</string>


### PR DESCRIPTION
Now "Create" button is not enabled for a folder whose name consists of a dot