### PR TITLE
Fix action triggers

### DIFF
--- a/.github/workflows/upload-app.yml
+++ b/.github/workflows/upload-app.yml
@@ -2,7 +2,7 @@ name: Upload Release Files to AWS S3
 
 on:
   release:
-    types: [released]
+    types: [released, edited, created]
 
 jobs:
   upload-release:


### PR DESCRIPTION
Look's like when trying to attach some binaries to release, this mean that you edit release. So look's like `edited ` trigget is required

@agolybev  Check it, please.